### PR TITLE
⬆️ Bump Zig to 0.16.0

### DIFF
--- a/.github/workflows/zig_test.yml
+++ b/.github/workflows/zig_test.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: mlugg/setup-zig@v1
         with:
-          version: 0.15.1
+          version: 0.16.0
       - run: zig build test
   lint:
     runs-on: ubuntu-latest
@@ -31,5 +31,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: mlugg/setup-zig@v1
         with:
-          version: 0.15.1
+          version: 0.16.0
       - run: zig fmt --check .

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Chroma
 
-**Version:** 0.15.1  
-**License:** MIT  
+**Zig Version:** 0.16.0<br>
+**License:** MIT<br>
 **Language:** [Zig](https://ziglang.org)
 
 Chroma is a Zig library for advanced ANSI color and text styling in terminal output. It allows developers to dynamically format strings with embedded placeholders (e.g. `{red}`, `{bold}`, `{fg:255;100;0}` for true color) and converts them into ANSI escape sequences. This makes it easy to apply complex styles, switch between foreground/background colors, and reset formatting on the fly—all at compile time.
@@ -42,7 +42,7 @@ Or manually paste this in your `build.zig.zon`
     // other deps...
     .chroma = .{
         .url = "https://github.com/adia-dev/chroma-zig/archive/refs/heads/main.zip",
-        .hash = "12209a8a991121bba3b21f31d275588690dc7c0d7fa9c361fd892e782dd88e0fb2ba",
+        .hash = "chroma-0.1.2-dA-RkbRIAACztjsL_aHnaZqu3GB53kpZziNo_TdxiLnf",
     },
     // ...
 },
@@ -58,11 +58,16 @@ Or manually paste this in your `build.zig.zon`
        const target = b.standardTargetOptions(.{});
        const optimize = b.standardOptimizeOption(.{});
 
-       const lib = b.addStaticLibrary(.{
-           .name = "chroma",
-           .root_source_file = .{ .src_path = .{ .owner = b, .sub_path = "src/lib.zig" } },
+       const mod = b.addModule("chroma", .{
+           .root_source_file = b.path("src/lib.zig"),
            .target = target,
            .optimize = optimize,
+       });
+
+       const lib = b.addLibrary(.{
+           .name = "chroma",
+           .linkage = .static,
+           .root_module = mod,
        });
 
        b.installArtifact(lib);
@@ -137,12 +142,9 @@ If all tests pass, you’re good to go!
 
 Chroma works out-of-the-box. For more complex scenarios (e.g., custom labels, multiple color formats), refer to `src/lib.zig` and `src/ansi.zig` for detailed code comments that explain available options and their intended usage.
 
-## 📦 New in Version 0.15.1
+## 📦 Zig Compatibility
 
-- **Updated Compatibility:** Now aligned with Zig `0.15.1`.
-- **Improved Parser Logic:** More robust handling of multiple formats within the same placeholder.
-- **Better Testing:** Additional tests ensure extended color and true color formats behave as expected.
-- **Performance Tweaks:** Minor compile-time optimizations for faster builds.
+Chroma targets Zig 0.16.0. The minimum supported compiler is declared in `build.zig.zon`, and CI validates this version.
 
 ## 🤝 Contributing
 

--- a/build.zig
+++ b/build.zig
@@ -4,8 +4,8 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const mod = b.addModule("chroma", .{ 
-        .root_source_file = .{ .src_path = .{ .owner = b, .sub_path = "src/lib.zig" } },
+    const mod = b.addModule("chroma", .{
+        .root_source_file = b.path("src/lib.zig"),
         .target = target,
         .optimize = optimize,
     });
@@ -19,7 +19,7 @@ pub fn build(b: *std.Build) void {
     b.installArtifact(lib);
 
     const exe_mod = b.addModule("chroma-exe", .{
-        .root_source_file = .{ .src_path = .{ .owner = b, .sub_path = "src/main.zig" } },
+        .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
     });

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,10 +5,8 @@
     .version = "0.1.2",
     .fingerprint = 0xfebb40f591910f74,
 
-    // This field is optional.
-    // This is currently advisory only; Zig does not yet do anything
-    // with this value.
-    .minimum_zig_version = "0.15.1",
+    // Tracks the earliest Zig version supported by this package.
+    .minimum_zig_version = "0.16.0",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.


### PR DESCRIPTION
## What changed

- require Zig 0.16.0 in package metadata and CI
- adopt the Zig 0.16 `b.path` build API
- refresh the README build example, compatibility note, and package hash

## Why

The repository still targeted Zig 0.15.1. This moves the supported toolchain and contributor checks to Zig 0.16.0 without changing Chroma's formatting API.

## Validation

- `zig fmt --check .`
- `zig build`
- `zig build test`
- `zig build run`
- verified the Zig 0.16 package hash from an isolated package directory
